### PR TITLE
Router

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ src/jasmine-favicon-reporter/
 src/jasmine-jsreporter/
 src/jquery/
 src/ladda-bootstrap/
+src/lodash/
 src/mustache/
 src/proj4/
 src/put-selector/

--- a/_SpecRunner.html
+++ b/_SpecRunner.html
@@ -40,6 +40,8 @@
   
   <script src="src/app/tests/spec/SpecApp.js"></script>
   
+  <script src="src/app/tests/spec/Spec_router.js"></script>
+  
   <script src="src/app/tests/spec/SpecjsReporterSanitizer.js"></script>
   
   <script src=".grunt/grunt-contrib-jasmine/reporter.js"></script>

--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,8 @@
     "stubmodule": "^0.6",
     "util": "dojo-util#^1.10",
     "jasmine-jsreporter": "^0.1.2",
-    "xstyle": "09b4d603f63df3e7aa5acc04784e36710a75671d"
+    "xstyle": "09b4d603f63df3e7aa5acc04784e36710a75671d",
+    "lodash": "3.9.3-amd"
   },
   "resolutions": {
     "xstyle": "09b4d603f63df3e7aa5acc04784e36710a75671d"

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -2,6 +2,7 @@ define([
     './config',
 
     'app/mapController',
+    'app/router',
 
     'dijit/_TemplatedMixin',
     'dijit/_WidgetBase',
@@ -17,6 +18,7 @@ define([
     config,
 
     mapController,
+    router,
 
     _TemplatedMixin,
     _WidgetBase,

--- a/src/app/config.js
+++ b/src/app/config.js
@@ -46,6 +46,11 @@ define(['dojo/has', 'esri/config'], function (has, esriConfig) {
     } else if (has('agrc-build') === 'stage') {
         // test.mapserv.utah.gov
         window.AGRC.apiKey = 'AGRC-AC122FA9671436';
+
+        var fragment = window.AGRC.urls.mapService;
+        window.AGRC.urls.MapService = 'https://wrimaps.at.utah.gov' + fragment;
+
+        esriConfig.defaults.io.corsEnabledServers.push('wrimaps.at.utah.gov');
     } else {
         // localhost
         window.AGRC.apiKey = 'AGRC-E5B94F99865799';

--- a/src/app/config.js
+++ b/src/app/config.js
@@ -15,7 +15,7 @@ define(['dojo/has', 'esri/config'], function (has, esriConfig) {
 
         // version.: String
         //      The version number.
-        version: '0.1.0',
+        version: '0.1.0#router',
 
         // apiKey: String
         //      The api key used for services on api.mapserv.utah.gov

--- a/src/app/config.js
+++ b/src/app/config.js
@@ -22,6 +22,17 @@ define(['dojo/has', 'esri/config'], function (has, esriConfig) {
         apiKey: '', // acquire at developer.mapserv.utah.gov
 
         urls: {
+            mapService: '/arcgis/rest/services/WRI/MapService/MapServer'
+        },
+
+        layerIndices: {
+            point: 0,
+            line: 1,
+            poly: 2
+        },
+
+        fieldNames: {
+            Project_ID: 'Project_ID'
         }
     };
 

--- a/src/app/config.js
+++ b/src/app/config.js
@@ -33,6 +33,10 @@ define(['dojo/has', 'esri/config'], function (has, esriConfig) {
 
         fieldNames: {
             Project_ID: 'Project_ID'
+        },
+
+        topics: {
+            projectIdsChanged: 'wri/projectIdsChanged'
         }
     };
 

--- a/src/app/mapController.js
+++ b/src/app/mapController.js
@@ -1,17 +1,28 @@
 define([
-    'agrc/widgets/map/BaseMap'
+    'agrc/widgets/map/BaseMap',
+
+    'app/router',
+
+    'dojo/when'
 ], function (
-    BaseMap
+    BaseMap,
+
+    router,
+
+    when
 ) {
     return {
         initMap: function (mapDiv) {
             // summary:
             //      Sets up the map
-            console.info('app.App::initMap', arguments);
+            console.info('mapController/initMap', arguments);
 
-            this.map = new BaseMap(mapDiv, {
-                showAttribution: false,
-                defaultBaseMap: "Hybrid"
+            when(router.getInitialExtent(), function (extent) {
+                this.map = new BaseMap(mapDiv, {
+                    showAttribution: false,
+                    defaultBaseMap: "Hybrid",
+                    extent: extent
+                });
             });
         }
     };

--- a/src/app/mapController.js
+++ b/src/app/mapController.js
@@ -48,9 +48,7 @@ define([
             var baseLayer = that.map.getLayer(that.map.layerIds[0]);
             baseLayer.suspend();
 
-            that.addLayers();
-
-            that.map.on('load', function () {
+            that.addLayers().then(function () {
                 that.selectLayers().then(lang.hitch(baseLayer, 'resume'));
             });
 
@@ -106,13 +104,26 @@ define([
 
             var li = config.layerIndices;
             var that = this;
+            var deferreds = [];
+
             [li.poly, li.line, li.point].forEach(function (i) {
-                that.layers.push(new FeatureLayer(config.urls.mapService + '/' + i, {
+                var layer = new FeatureLayer(config.urls.mapService + '/' + i, {
                     mode: FeatureLayer.MODE_SELECTION
-                }));
+                });
+
+                var deferred = new Deferred();
+
+                layer.on('load', function () {
+                    deferred.resolve();
+                });
+
+                deferreds.push(deferred);
+                that.layers.push(layer);
             });
 
             this.map.addLayers(this.layers);
+
+            return all(deferreds);
         }
     };
 });

--- a/src/app/mapController.js
+++ b/src/app/mapController.js
@@ -34,7 +34,7 @@ define([
 
         initMap: function (mapDiv) {
             // summary:
-            //      Sets up the map
+            //      Sets up the map and layers
             console.info('app/mapController/initMap', arguments);
 
             var that = this;
@@ -42,6 +42,9 @@ define([
                 showAttribution: false,
                 defaultBaseMap: "Hybrid"
             });
+
+            // suspend base map layer until we get the initial extent
+            // trying to save requests to the server
             var baseLayer = that.map.getLayer(that.map.layerIds[0]);
             baseLayer.suspend();
 
@@ -55,13 +58,14 @@ define([
         },
         selectLayers: function () {
             // summary:
-            //      selects the feature layers appropriate for the current project ids
+            //      selects the feature layers based upon the current project ids
             // returns: Promise
             console.log('app/mapController:selectLayers', arguments);
 
             var def = new Deferred();
             var q = new Query();
             q.where = router.getProjectsWhereClause();
+            // don't show all features for feature layers
             if (q.where !== '1 = 1') {
                 this.layers.forEach(function (lyr) {
                     lyr.selectFeatures(q);
@@ -85,6 +89,7 @@ define([
                     def.resolve();
                 });
             } else {
+                // TODO: show centroids
                 def.resolve();
             }
 

--- a/src/app/mapController.js
+++ b/src/app/mapController.js
@@ -71,6 +71,7 @@ define([
                 this.layers.forEach(function (lyr) {
                     deferreds.push(lyr.selectFeatures(q));
                 });
+
                 var that = this;
                 all(deferreds).then(function (graphics) {
                     if (graphics === null) {
@@ -100,6 +101,7 @@ define([
         addLayers: function () {
             // summary:
             //      Adds the layers to the map
+            // returns: Promise when all layers have been loaded
             console.log('app/mapController:addLayers', arguments);
 
             var li = config.layerIndices;

--- a/src/app/mapController.js
+++ b/src/app/mapController.js
@@ -1,29 +1,109 @@
 define([
     'agrc/widgets/map/BaseMap',
 
+    'app/config',
     'app/router',
 
-    'dojo/when'
+    'dojo/_base/lang',
+    'dojo/Deferred',
+    'dojo/topic',
+    'dojo/when',
+
+    'esri/geometry/Extent',
+    'esri/layers/FeatureLayer',
+    'esri/tasks/query'
 ], function (
     BaseMap,
 
+    config,
     router,
 
-    when
+    lang,
+    Deferred,
+    topic,
+    when,
+
+    Extent,
+    FeatureLayer,
+    Query
 ) {
     return {
+        // layers: FeatureLayer[]
+        //      POINT, LINE & POLY layers
+        layers: [],
+
         initMap: function (mapDiv) {
             // summary:
             //      Sets up the map
-            console.info('mapController/initMap', arguments);
+            console.info('app/mapController/initMap', arguments);
 
-            when(router.getInitialExtent(), function (extent) {
-                this.map = new BaseMap(mapDiv, {
-                    showAttribution: false,
-                    defaultBaseMap: "Hybrid",
-                    extent: extent
-                });
+            var that = this;
+            that.map = new BaseMap(mapDiv, {
+                showAttribution: false,
+                defaultBaseMap: "Hybrid"
             });
+            var baseLayer = that.map.getLayer(that.map.layerIds[0]);
+            baseLayer.suspend();
+
+            that.addLayers();
+
+            that.map.on('load', function () {
+                that.selectLayers().then(lang.hitch(baseLayer, 'resume'));
+            });
+
+            topic.subscribe(config.topics.projectIdsChanged, lang.hitch(that, 'selectLayers'));
+        },
+        selectLayers: function () {
+            // summary:
+            //      selects the feature layers appropriate for the current project ids
+            // returns: Promise
+            console.log('app/mapController:selectLayers', arguments);
+
+            var def = new Deferred();
+            var q = new Query();
+            q.where = router.getProjectsWhereClause();
+            if (q.where !== '1 = 1') {
+                this.layers.forEach(function (lyr) {
+                    lyr.selectFeatures(q);
+                });
+                var that = this;
+                when(router.getProjectIdsExtent(), function (extent) {
+                    if (extent === null) {
+                        // state of utah extent
+                        that.map.setExtent(new Extent({
+                            xmax: 696328,
+                            xmin: 207131,
+                            ymax: 4785283,
+                            ymin: 3962431,
+                            spatialReference: {
+                                wkid: 26912
+                            }
+                        }));
+                    } else {
+                        that.map.setExtent(extent, true);
+                    }
+                    def.resolve();
+                });
+            } else {
+                def.resolve();
+            }
+
+            return def.promise;
+        },
+        addLayers: function () {
+            // summary:
+            //      Adds the layers to the map
+            console.log('app/mapController:addLayers', arguments);
+
+            var li = config.layerIndices;
+            var that = this;
+            [li.poly, li.line, li.point].forEach(function (i) {
+                that.layers.push(new FeatureLayer(config.urls.mapService + '/' + i, {
+                    mode: FeatureLayer.MODE_SELECTION
+                }));
+            });
+
+            this.map.addLayers(this.layers);
         }
     };
 });

--- a/src/app/router.js
+++ b/src/app/router.js
@@ -39,7 +39,7 @@ define([
 
         startup: function () {
             // summary:
-            //      description
+            //      spin up and get everything set up
             console.log('app/router::startup', arguments);
 
             topic.subscribe('/dojo/hashchange', lang.hitch(this, 'onHashChange'));
@@ -51,7 +51,9 @@ define([
         },
         onHashChange: function (newHash) {
             // summary:
-            //      fires anytime the hash in the URL changes
+            //      Fires anytime the hash in the URL changes.
+            //      Check for changes to hash props that we care about
+            //      and fire relevant events.
             // newHash: String
             console.log('app/router:onHashChange', arguments);
 
@@ -88,7 +90,7 @@ define([
         },
         getProjectsWhereClause: function () {
             // summary:
-            //      returns a where class for the current project ids
+            //      returns a definition query containing the current project ids
             // returns: String
             console.log('app/router:getProjectsWhereClause', arguments);
 
@@ -113,6 +115,7 @@ define([
 
             var that = this;
             var makeRequest = function (index) {
+                // query for extent of all features that match the query
                 var url = dojoString.substitute('${0}/${1}/query', [config.urls.mapService, index]);
                 return request.get(url, {
                     query: {

--- a/src/app/router.js
+++ b/src/app/router.js
@@ -142,7 +142,7 @@ define([
                         if (!unionedExtent) {
                             unionedExtent = newExtent;
                         } else {
-                            unionedExtent.union(newExtent);
+                            unionedExtent = unionedExtent.union(newExtent);
                         }
                     }
                 });

--- a/src/app/router.js
+++ b/src/app/router.js
@@ -1,0 +1,139 @@
+define([
+    'app/config',
+
+    'dojo/_base/lang',
+    'dojo/Deferred',
+    'dojo/hash',
+    'dojo/io-query',
+    'dojo/promise/all',
+    'dojo/request',
+    'dojo/string',
+    'dojo/topic',
+
+    'esri/geometry/Extent',
+
+    'lodash/array/difference'
+], function (
+    config,
+
+    lang,
+    Deferred,
+    hash,
+    ioQuery,
+    all,
+    request,
+    dojoString,
+    topic,
+
+    Extent,
+
+    difference
+) {
+    var obj = {
+        // description:
+        //      Parse and update the URL parameters used to set and preserve the state of the application
+
+        // projectIds: String []
+        //      The id or id's of the currently displayed projects
+        projectIds: [],
+
+        startup: function () {
+            // summary:
+            //      description
+            console.log('app/router::startup', arguments);
+
+            topic.subscribe('/dojo/hashchange', lang.hitch(this, 'onHashChange'));
+
+            var beginHash = hash();
+            if (beginHash) {
+                this.onHashChange(beginHash);
+            }
+        },
+        onHashChange: function (newHash) {
+            // summary:
+            //      fires anytime the hash in the URL changes
+            // newHash: String
+            console.log('app/router:onHashChange', arguments);
+
+            var newProps = ioQuery.queryToObject(newHash);
+            newProps.id = (typeof newProps.id === 'string') ? [newProps.id] : newProps.id;
+            if (difference(newProps.id.sort(), this.projectIds.sort()).length > 0) {
+                this.onIdsChange(newProps.id);
+            }
+            this.projectIds = newProps.id;
+        },
+        setHash: function (props) {
+            // summary:
+            //      updates the URL with the properties
+            // props: Object
+            //      id: String || String[]
+            console.log('app/router:setHash', arguments);
+
+            hash(ioQuery.objectToQuery(props));
+        },
+        onIdsChange: function (/*newIds*/) {
+            // summary:
+            //      fires when the project ids in the hash have changed
+            // newIds: String[]
+            console.log('app/router:onIdsChange', arguments);
+
+        },
+        getInitialExtent: function () {
+            // summary:
+            //      if there are existing id(s) then query the server and return extent
+            //      otherwise return null so that the default extent is used
+            // returns: Promise || null
+            console.log('app/router:getInitialExtent', arguments);
+
+            if (!this.projectIds) {
+                return null;
+            }
+
+            var id_nums = this.projectIds.map(function (id) {
+                return parseInt(id, 10);
+            });
+            var where = dojoString.substitute('${0} IN (${1})', [config.fieldNames.Project_ID, id_nums]);
+
+            var makeRequest = function (index) {
+                var url = dojoString.substitute('${0}/${1}/query', [config.urls.mapService, index]);
+                return request.get(url, {
+                    query: {
+                        returnExtentOnly: true,
+                        where: where,
+                        f: 'json'
+                    },
+                    handleAs: 'json'
+                });
+            };
+
+            var promises = [];
+            var li = config.layerIndices;
+            [li.point, li.line, li.poly].forEach(function (i) {
+                promises.push(makeRequest(i));
+            });
+
+            var def = new Deferred();
+            all(promises).then(function (extents) {
+                var unionedExtent;
+                extents.forEach(function (e) {
+                    if (!isNaN(e.extent.xmin)) {
+                        var newExtent = new Extent(e.extent);
+                        if (!unionedExtent) {
+                            unionedExtent = newExtent;
+                        } else {
+                            unionedExtent.union(newExtent);
+                        }
+                    }
+                });
+
+                def.resolve(unionedExtent);
+            });
+
+            return def.promise;
+        }
+    };
+
+    obj.startup();
+
+    return obj;
+});

--- a/src/app/run.js
+++ b/src/app/run.js
@@ -18,6 +18,7 @@
             'dojox',
             'esri',
             'ijit',
+            'lodash',
             'proj4',
             'put-selector',
             'xstyle',

--- a/src/app/tests/spec/Spec_router.js
+++ b/src/app/tests/spec/Spec_router.js
@@ -37,13 +37,18 @@ require([
                 router.onHashChange('id=1&id=2&id=3');
 
                 expect(router.projectIds).toEqual(['1', '2', '3']);
+
+                router.onHashChange('test=1');
+
+                expect(router.projectIds).toEqual([]);
             });
             it('calls update functions if new values', function () {
                 router.projectIds = [];
                 router.onHashChange('id=1');
                 router.onHashChange('id=1&id=2');
+                router.onHashChange('id=1');
 
-                expect(router.onIdsChange.calls.count()).toBe(2);
+                expect(router.onIdsChange.calls.count()).toBe(3);
             });
             it('doesn\'t call update if not new values', function () {
                 router.projectIds = ['1'];
@@ -54,16 +59,22 @@ require([
                 expect(router.onIdsChange).not.toHaveBeenCalled();
             });
         });
-        describe('getInitialExtent', function () {
+        describe('getProjectIdsExtent', function () {
             it('returns null if there are no project ids', function () {
-                router.projectIds = null;
+                router.projectIds = [];
 
-                expect(router.getInitialExtent()).toBeNull();
+                expect(router.getProjectIdsExtent()).toBeNull();
             });
             it('returns a promise if there are project ids', function () {
                 router.projectIds = ['1', '2'];
 
-                expect(router.getInitialExtent()).toEqual(jasmine.any(Promise));
+                expect(router.getProjectIdsExtent()).toEqual(jasmine.any(Promise));
+            });
+        });
+        describe('getProjectsWhereClause', function () {
+            it('returns 1=1 if not project ids are specified', function () {
+                router.projectIds = [];
+                expect(router.getProjectsWhereClause()).toBe('1 = 1');
             });
         });
     });

--- a/src/app/tests/spec/Spec_router.js
+++ b/src/app/tests/spec/Spec_router.js
@@ -1,0 +1,70 @@
+require([
+    'app/router',
+
+    'dojo/hash',
+    'dojo/promise/Promise'
+], function (
+    router,
+
+    hash,
+    Promise
+) {
+    describe('app/router', function () {
+        afterEach(function () {
+            hash('');
+        });
+
+        describe('setHash', function () {
+            it('sets the correct URL parameters', function () {
+                router.setHash({id: 1});
+
+                expect(hash()).toContain('id=1');
+
+                router.setHash({id: [1, 2, 3]});
+
+                expect(hash()).toContain('id=1&id=2&id=3');
+            });
+        });
+        describe('onHashChange', function () {
+            beforeEach(function () {
+                spyOn(router, 'onIdsChange');
+            });
+            it('updates the properties of the router', function () {
+                router.onHashChange('id=1');
+
+                expect(router.projectIds).toEqual(['1']);
+
+                router.onHashChange('id=1&id=2&id=3');
+
+                expect(router.projectIds).toEqual(['1', '2', '3']);
+            });
+            it('calls update functions if new values', function () {
+                router.projectIds = [];
+                router.onHashChange('id=1');
+                router.onHashChange('id=1&id=2');
+
+                expect(router.onIdsChange.calls.count()).toBe(2);
+            });
+            it('doesn\'t call update if not new values', function () {
+                router.projectIds = ['1'];
+                router.onHashChange('id=1');
+                router.projectIds = ['1', '2'];
+                router.onHashChange('id=2&id=1');
+
+                expect(router.onIdsChange).not.toHaveBeenCalled();
+            });
+        });
+        describe('getInitialExtent', function () {
+            it('returns null if there are no project ids', function () {
+                router.projectIds = null;
+
+                expect(router.getInitialExtent()).toBeNull();
+            });
+            it('returns a promise if there are project ids', function () {
+                router.projectIds = ['1', '2'];
+
+                expect(router.getInitialExtent()).toEqual(jasmine.any(Promise));
+            });
+        });
+    });
+});

--- a/src/app/tests/spec/Spec_router.js
+++ b/src/app/tests/spec/Spec_router.js
@@ -1,13 +1,11 @@
 require([
     'app/router',
 
-    'dojo/hash',
-    'dojo/promise/Promise'
+    'dojo/hash'
 ], function (
     router,
 
-    hash,
-    Promise
+    hash
 ) {
     describe('app/router', function () {
         afterEach(function () {
@@ -57,24 +55,6 @@ require([
                 router.onHashChange('id=2&id=1');
 
                 expect(router.onIdsChange).not.toHaveBeenCalled();
-            });
-        });
-        describe('getProjectIdsExtent', function () {
-            it('returns null if there are no project ids', function () {
-                router.projectIds = [];
-
-                expect(router.getProjectIdsExtent()).toBeNull();
-            });
-            it('returns a promise if there are project ids', function () {
-                router.projectIds = ['1', '2'];
-
-                expect(router.getProjectIdsExtent()).toEqual(jasmine.any(Promise));
-            });
-        });
-        describe('getProjectsWhereClause', function () {
-            it('returns 1=1 if not project ids are specified', function () {
-                router.projectIds = [];
-                expect(router.getProjectsWhereClause()).toBe('1 = 1');
             });
         });
     });


### PR DESCRIPTION
Handles everything for displaying features from multiple or single projects. Not sure that this is great for multiple projects since adjacent projects may want to be symbolized differently but nevertheless a good start.

I picture all view switching between single, multiple or all projects being driven by the hash. Some examples are:

http://127.0.0.1/projects/wri-web/src/#id=1636
http://127.0.0.1/projects/wri-web/src/#id=1636&id=3362
http://127.0.0.1/projects/wri-web/src/

Works with forward and backward buttons without reloading the application.

@steveoh Would appreciate a code review if you have the time.