### PR TITLE
Better build config

### DIFF
--- a/GruntFile.js
+++ b/GruntFile.js
@@ -143,7 +143,12 @@ module.exports = function (grunt) {
             built: {
                 options: {
                     port: port,
-                    base: './dist',
+                    base: {
+                        path: './dist/map',
+                        options: {
+                            index: 'map.html'
+                        }
+                    },
                     logger: 'dev',
                     middleware: function (connect, options, defaultMiddleware) {
                         var proxy = require('grunt-connect-proxy/lib/utils').proxyRequest;

--- a/GruntFile.js
+++ b/GruntFile.js
@@ -98,7 +98,7 @@ module.exports = function (grunt) {
             }
         },
         clean: {
-            build: ['dist'],
+            build: ['dist/js/agrc', 'dist/map'],
             all: {
                 options: {
                     force: true
@@ -140,6 +140,33 @@ module.exports = function (grunt) {
                     }
                 ]
             },
+            built: {
+                options: {
+                    port: port,
+                    base: './dist',
+                    logger: 'dev',
+                    middleware: function (connect, options, defaultMiddleware) {
+                        var proxy = require('grunt-connect-proxy/lib/utils').proxyRequest;
+                        return [proxy].concat(defaultMiddleware);
+                    }
+                },
+                proxies: [
+                    {
+                        context: '/arcgis',
+                        host: secrets.devHost,
+                        headers: {
+                            connection: 'keep-alive'
+                        }
+                    },
+                    {
+                        context: '/wri/api',
+                        host: secrets.devHost,
+                        headers: {
+                            connection: 'keep-alive'
+                        }
+                    }
+                ]
+            },
             jasmine: {
                 options: {
                     port: jasminePort,
@@ -158,7 +185,7 @@ module.exports = function (grunt) {
                     expand: true,
                     cwd: 'src/',
                     src: ['*.html'],
-                    dest: 'dist/'
+                    dest: 'dist/map/'
                 }]
             },
             all: {
@@ -190,14 +217,14 @@ module.exports = function (grunt) {
 
                     ],
                     dest: 'C:/Projects/svn/dnr-wri/src/main/webapp/js/agrc/',
-                    cwd: 'dist/',
+                    cwd: 'dist/js/agrc/',
                     expand: true
                 }]
             },
             dts: {
                 files: {
-                    'C:/Projects/svn/dnr-wri/src/main/webapp/js/agrc/dojo/dojo.js': 'C:/Projects/GitHub/wri-web/dist/dojo/dojo.js',
-                    'C:/Projects/svn/dnr-wri/src/main/webapp/js/agrc/app/resources/App.css': 'C:/Projects/GitHub/wri-web/dist/app/resources/App.css'
+                    'C:/Projects/svn/dnr-wri/src/main/webapp/js/agrc/dojo/dojo.js': 'C:/Projects/GitHub/wri-web/dist/js/agrc/dojo/dojo.js',
+                    'C:/Projects/svn/dnr-wri/src/main/webapp/js/agrc/app/resources/App.css': 'C:/Projects/GitHub/wri-web/dist/js/agrc/app/resources/App.css'
                 }
             }
         },
@@ -218,7 +245,7 @@ module.exports = function (grunt) {
                 // You can also specify options to be used in all your tasks
                 dojo: 'src/dojo/dojo.js', // Path to dojo.js file in dojo source
                 load: 'build', // Optional: Utility to bootstrap (Default: 'build')
-                releaseDir: '../dist',
+                releaseDir: '../dist/js/agrc',
                 require: 'src/app/run.js', // Optional: Module to require for the build (Default: nothing)
                 basePath: './src'
             }
@@ -260,8 +287,8 @@ module.exports = function (grunt) {
                         'src/jasmine-favicon-reporter/vendor/favico.js',
                         'src/jasmine-favicon-reporter/jasmine-favicon-reporter.js',
                         'src/jasmine-jsreporter/jasmine-jsreporter.js',
-                        'src/app/tests/jasmineTestBootstrap.js',
                         'src/dojo/dojo.js',
+                        'src/app/tests/jasmineTestBootstrap.js',
                         'src/app/tests/jsReporterSanitizer.js',
                         'src/app/tests/jasmineAMDErrorChecking.js'
                     ],
@@ -300,7 +327,7 @@ module.exports = function (grunt) {
             options: {},
             main: {
                 files: {
-                    'dist/index.html': ['src/index.html']
+                    'dist/map/map.html': ['src/index.html']
                 }
             }
         },
@@ -338,6 +365,9 @@ module.exports = function (grunt) {
             stylus: {
                 files: 'src/app/**/*.styl',
                 tasks: ['stylus']
+            },
+            built: {
+                files: 'dist/**/*.*'
             }
         }
     });
@@ -383,7 +413,8 @@ module.exports = function (grunt) {
     ]);
     grunt.registerTask('sauce', [
         'jasmine:main:build',
-        'connect',
+        'connect:jasmine',
+        'connect:server',
         'saucelabs-jasmine'
     ]);
     grunt.registerTask('travis', [
@@ -392,5 +423,10 @@ module.exports = function (grunt) {
         'jscs:main',
         'sauce',
         'build-prod'
+    ]);
+    grunt.registerTask('serve-built', [
+        'configureProxies:built',
+        'connect:built',
+        'watch:built'
     ]);
 };

--- a/_SpecRunner.html
+++ b/_SpecRunner.html
@@ -28,9 +28,9 @@
   
   <script src="src/jasmine-jsreporter/jasmine-jsreporter.js"></script>
   
-  <script src="src/app/tests/jasmineTestBootstrap.js"></script>
-  
   <script src="src/dojo/dojo.js"></script>
+  
+  <script src="src/app/tests/jasmineTestBootstrap.js"></script>
   
   <script src="src/app/tests/jsReporterSanitizer.js"></script>
   

--- a/profiles/build.profile.js
+++ b/profiles/build.profile.js
@@ -1,8 +1,4 @@
 /*jshint unused:false */
-
-var trueFunc = function () {
-    return true;
-};
 var profile = {
     basePath: '../src',
     action: 'release',

--- a/profiles/build.profile.js
+++ b/profiles/build.profile.js
@@ -1,5 +1,8 @@
 /*jshint unused:false */
 
+var trueFunc = function () {
+    return true;
+};
 var profile = {
     basePath: '../src',
     action: 'release',

--- a/profiles/prod.build.profile.js
+++ b/profiles/prod.build.profile.js
@@ -2,5 +2,6 @@
 var profile = {
     staticHasFeatures: {
         'agrc-build': '"prod"'
-    }
+    },
+    baseUrl: '../js/agrc/'
 };

--- a/profiles/stage.build.profile.js
+++ b/profiles/stage.build.profile.js
@@ -2,5 +2,6 @@
 var profile = {
     staticHasFeatures: {
         'agrc-build': '"stage"'
-    }
+    },
+    baseUrl: '../js/agrc/'
 };

--- a/src/app/app.profile.js
+++ b/src/app/app.profile.js
@@ -14,7 +14,7 @@ profile = {
             return mid in {
                 'app/package': 1,
                 'app/tests/jasmineTestBootstrap': 1
-            };
+            } || /\.styl$/.test(filename);
         }
     }
 };

--- a/src/app/resources/App.styl
+++ b/src/app/resources/App.styl
@@ -1,11 +1,11 @@
-$icon-font-path = '../../bootstrap-stylus/fonts/';
-$nav-tabs-active-link-hover-border-color = #fff
-$nav-tabs-border-color = #fff
-
 @import '../../esri/css/esri.css';
 @import '../../agrc/resources/map/BaseMap.css';
 @import '../../agrc/resources/map/BaseMapSelector.css';
 @import '../../seiyria-bootstrap-slider/css/bootstrap-slider.css';
+
+$icon-font-path = '../../bootstrap-stylus/fonts/';
+$nav-tabs-active-link-hover-border-color = #fff
+$nav-tabs-border-color = #fff
 
 // bootstrap-stylus
 @require '../../bootstrap-stylus/bootstrap/component-animations';

--- a/src/app/run.js
+++ b/src/app/run.js
@@ -1,14 +1,5 @@
 (function () {
-    // the baseUrl is relavant in source version and while running unit tests.
-    // the`typeof` is for when this file is passed as a require argument to the build system
-    // since it runs on node, it doesn't have a window object. The basePath for the build system
-    // is defined in build.profile.js
     var config = {
-        baseUrl: (
-            typeof window !== 'undefined' &&
-            window.dojoConfig &&
-            window.dojoConfig.isJasmineTestRunner
-            ) ? '/src' : './',
         packages: [
             'agrc',
             'app',
@@ -23,7 +14,6 @@
             'esri',
             'ijit',
             'lodash',
-            'proj4',
             'put-selector',
             'xstyle',
             {

--- a/src/app/tests/jasmineTestBootstrap.js
+++ b/src/app/tests/jasmineTestBootstrap.js
@@ -1,8 +1,6 @@
 /* global JasmineFaviconReporter, jasmineRequire */
 /*jshint unused:false*/
-var dojoConfig = {
-    // isDebug: false,
-    isJasmineTestRunner: true,
+require({
     packages: [{
         name: 'agrc-jasmine-matchers',
         location: 'agrc-jasmine-matchers/src'
@@ -13,8 +11,9 @@ var dojoConfig = {
     }],
     has: {
         'dojo-undef-api': true
-    }
-};
+    },
+    baseUrl: '/src/'
+});
 
 // for jasmine-favicon-reporter
 jasmine.getEnv().addReporter(new JasmineFaviconReporter());

--- a/src/index.html
+++ b/src/index.html
@@ -14,10 +14,19 @@
     <script src='/wri/js/vendor/html5.js' type='text/javascript'></script>
     <![endif]-->
     <!-- CSS -->
+    <link rel="stylesheet" type="text/css" href="https://wri.dev.utah.gov/wri/css/dnr-style.css">
+
+
+
+    <!-- build:template
+    <link rel='stylesheet' href='../js/agrc/app/resources/App.css'>
+    /build -->
     <!-- build:remove -->
-    <link rel="stylesheet" type="text/css" href="dts/dnr-style.css">
-    <!-- /build -->
     <link rel='stylesheet' href='app/resources/App.css'>
+    <!-- /build -->
+
+
+
     <link href='//fonts.googleapis.com/css?family=Raleway:400,700,600' rel='stylesheet' type='text/css' media='all'>
     <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css' media='all'>
     <link href='//fonts.googleapis.com/css?family=Oswald:400,700' rel='stylesheet' type='text/css' media='all'>
@@ -67,13 +76,24 @@
                         </div>
                     </div>
                 </div>
+
+
+
                 <!-- build:template
-                <script data-dojo-config="deps:['app/run']" src='dojo/dojo.js'></script>
+                <script data-dojo-config="deps:['app/run']" src='../js/agrc/dojo/dojo.js'></script>
                 /build -->
                 <!-- build:remove -->
-                <script data-dojo-config="isDebug: 1" src='dojo/dojo.js'></script>
+                <script src='dojo/dojo.js'></script>
+                <script type="text/javascript">
+                    require({
+                        baseUrl: '../'
+                    });
+                </script>
                 <script src='app/run.js'></script>
                 <!-- /build -->
+
+
+                
                 <div id="footer-wrapper" class="site-full">
                     <div id="footer" class="site">
                         <div class="stateFooterLinks right">


### PR DESCRIPTION
Puts built version in a similar folder structure to the app server. This allows for better testing of the built app including the addition of a `grunt serve-built` command.

Reconfigures `baseUrl` for built versions to work with the weird folder structure mentioned above.

Don't copy `.styl` files to the built version of the app. I was running into a problem with my simple web server auto-compiling them and overwriting `App.css`.

Fixes #22