### PR TITLE
Fix flakey tests

### DIFF
--- a/src/app/tests/spec/SpecToasterItem.js
+++ b/src/app/tests/spec/SpecToasterItem.js
@@ -55,23 +55,27 @@ require([
             });
         });
         describe('show', function () {
-            it('hides destroys itself after timeout', function (done) {
+            beforeEach(function () {
+                jasmine.clock().install();
+            });
+            afterEach(function () {
+                jasmine.clock().uninstall();
+            });
+            it('hides destroys itself after timeout', function () {
                 widget = new WidgetUnderTest({
                     message: 'test',
                     cssClass: 'info',
                     duration: 1
                 }, domConstruct.create('div', null, document.body));
                 widget.startup();
+                spyOn(widget.hideAnim, 'play');
 
                 widget.show();
+                jasmine.clock().tick(2);
 
-                window.setTimeout(function () {
-                    expect(widget.domNode).toBeNull();
-
-                    done();
-                }, 1200);
+                expect(widget.hideAnim.play).toHaveBeenCalled();
             });
-            it('sticky doesn\'t auto hide', function (done) {
+            it('sticky doesn\'t auto hide', function () {
                 widget = new WidgetUnderTest({
                     message: 'test',
                     cssClass: 'info',
@@ -79,14 +83,12 @@ require([
                     sticky: true
                 }, domConstruct.create('div', null, document.body));
                 widget.startup();
+                spyOn(widget.hideAnim, 'play');
 
                 widget.show();
+                jasmine.clock().tick(2);
 
-                window.setTimeout(function () {
-                    expect(widget.domNode).not.toBeNull();
-
-                    done();
-                }, 1200);
+                expect(widget.hideAnim.play).not.toHaveBeenCalled();
             });
         });
     });


### PR DESCRIPTION
I looked back at all of the failed sauce tests (mostly on Safari) and found that these were the culprits. 

After increasing the timeout, I ran these tests on sauce 4 or 5 times and they passed.