### PR TITLE
Only reset point symbols after select for editing

### DIFF
--- a/src/app/project/DrawToolbar.js
+++ b/src/app/project/DrawToolbar.js
@@ -108,7 +108,9 @@ define([
                 this.own(this.drawToolbar.on('draw-complete', lang.hitch(this, 'onDrawComplete')));
                 this.editToolbar = new Edit(this.map);
                 this.own(this.editToolbar.on('deactivate', function (evt) {
-                    evt.graphic.setSymbol(config.symbols.selected.point);
+                    if (evt.graphic.geometry.type === 'point') {
+                        evt.graphic.setSymbol(config.symbols.selected.point);
+                    }
                 }));
             }
 


### PR DESCRIPTION
Fixes regression bug in [#38973](https://redmine.dts.utah.gov/issues/38973)