### PR TITLE
Handle when map is already loaded

### DIFF
--- a/src/app/mapController.js
+++ b/src/app/mapController.js
@@ -123,13 +123,6 @@ define([
                 extent: config.defaultExtent
             });
 
-            this.layerSelector = new LayerSelector({
-                map: this.map,
-                quadWord: config.quadWord,
-                baseLayers: ['Lite', 'Hybrid', 'Terrain', 'Topo', 'Color IR'],
-                overlays: ['Overlay']
-            });
-
             this.map.on('load', function () {
                 that.map.disableDoubleClickZoom();
                 that.map.on('extent-change', function (change) {
@@ -161,6 +154,13 @@ define([
                 });
                 domClass.add(btn, 'toolbar-item');
                 domAttr.set(btn, 'title', 'Next Extent');
+            });
+
+            this.layerSelector = new LayerSelector({
+                map: this.map,
+                quadWord: config.quadWord,
+                baseLayers: ['Lite', 'Hybrid', 'Terrain', 'Topo', 'Color IR'],
+                overlays: ['Overlay']
             });
 
             this.map.on('zoom-end', function () {


### PR DESCRIPTION
Fixes https://redmine.dts.utah.gov/issues/39550

This was preventing all of that set up in the load event from not firing. Not sure when this broke but I'm kind of surprised that no one noticed the back and forward buttons were missing.